### PR TITLE
Add support to Gradle 8+

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -24,11 +24,20 @@ apply plugin: 'com.android.library'
 android {
     compileSdkVersion 28
 
+    if (project.android.hasProperty("namespace")) {
+        namespace 'yeniellandestoy.native_shared_preferences'
+    }
+
     defaultConfig {
         minSdkVersion 16
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
-    lintOptions {
+    lint {
         disable 'InvalidPackage'
+    }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
     }
 }


### PR DESCRIPTION
To support Gradle8+, add property `namespace`.