### PR TITLE
Fixing an iOS crash where a date within an array fails to serialize a…

### DIFF
--- a/ios/Classes/NativeSharedPreferencesPlugin.m
+++ b/ios/Classes/NativeSharedPreferencesPlugin.m
@@ -95,6 +95,8 @@
                     
                     [self mapDateToMilliseconds:(NSDictionary *)element mappedDictionary:newMappedDictionary];
                     [newArray addObject:newMappedDictionary];
+                } else if ([element isKindOfClass:[NSDate class]]) { 
+                    [newArray addObject:[NSNumber numberWithDouble:floor([((NSDate *)element) timeIntervalSince1970] * 1000)]];
                 } else {
                     [newArray addObject:element];
                 }


### PR DESCRIPTION
This PR fixes a crash If user defaults contains an array with dates.